### PR TITLE
Removed empty scope causing -Werror=misleading-indentation to fail

### DIFF
--- a/third_party/STM/CMSIS/CM3_f4xx/system_stm32f4xx.c
+++ b/third_party/STM/CMSIS/CM3_f4xx/system_stm32f4xx.c
@@ -415,8 +415,6 @@ static void SetSysClock(void)
 
     /* Wait till the main PLL is used as system clock source */
     while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
-    {
-    }
   }
   else
   { /* If HSE fails to start-up, the application will have wrong clock


### PR DESCRIPTION
Not sure if you're interested in this.
---
Pros: 
- IMHO always a good practice to eliminate warnings and to conform with `-Werror`
- When using `STM32CubeIDE` with default settings, the compiler currently fails:
![Bildschirmfoto 2020-10-08 um 17 18 44](https://user-images.githubusercontent.com/29398377/95478824-528c5f00-098a-11eb-9ca9-176fa6b05515.jpg)
- Only syntactic change, braces would be optimized away anyway
---
Cons: 
- Changing 3rd Party dependencies
