### PR TITLE
Size of RingBuffer needs to be a power of two

### DIFF
--- a/utils/ring_buffer.h
+++ b/utils/ring_buffer.h
@@ -37,7 +37,9 @@ namespace stmlib {
 template<typename T, size_t size>
 class RingBuffer {
  public:
-  RingBuffer() { }
+  RingBuffer() {
+    static_assert((size > 1) & !(size & (size - 1)), "RingBuffer size needs to be a power of 2");
+  }
   
   inline void Init() {
     read_ptr_ = write_ptr_ = 0;


### PR DESCRIPTION
For example this calculation

https://github.com/pichenettes/stmlib/blob/f7fc9db56988fd5c90e5659b9b0efa1429c43275/utils/ring_buffer.h#L53

implicitly calculates `((write_ptr_ - read_ptr_) % 2^32) % size`which is only identical to the intended calculation if `2^32 % size == 0` 
