### PR TITLE
Fix recursion

### DIFF
--- a/fft/shy_fft.h
+++ b/fft/shy_fft.h
@@ -88,8 +88,8 @@ template<>
 struct Math<double> {
   inline double pi() const { return 3.141592653589793; }
   inline float sqrt_2_div_2() const { return 0.7071067811865476; }
-  inline double cos(double x) { return cos(x); }
-  inline double sin(double x) { return sin(x); }
+  inline double cos(double x) { return std::cos(x); }
+  inline double sin(double x) { return std::sin(x); }
 };
 
 


### PR DESCRIPTION
`cos` and `sin` functions are calling themselves.
Since `cmath` is included we can just use the `std` methods here

Detected by clang on macOS
```
In file included from AudibleInstruments/src/Clouds.cpp:2:
In file included from AudibleInstruments/eurorack/clouds/dsp/granular_processor.h:43:
In file included from AudibleInstruments/eurorack/clouds/dsp/pvoc/phase_vocoder.h:34:
AudibleInstruments/eurorack/stmlib/fft/shy_fft.h:91:31: error: all paths through this function will call itself [-Werror,-Winfinite-recursion]
  inline double cos(double x) { return cos(x); }
                              ^
AudibleInstruments/eurorack/stmlib/fft/shy_fft.h:92:31: error: all paths through this function will call itself [-Werror,-Winfinite-recursion]
  inline double sin(double x) { return sin(x); }
                              ^
```
